### PR TITLE
Fix remaining amount update when saving transactions

### DIFF
--- a/src/main/java/edu/bhcc/SuperBudget/model/BudgetCategory.java
+++ b/src/main/java/edu/bhcc/SuperBudget/model/BudgetCategory.java
@@ -90,7 +90,13 @@ public class BudgetCategory {
             throw new IllegalArgumentException("Transaction amount exceeds the remaining budget.");
         }
 
+        // Deduct the transaction amount from both the balance and the
+        // remaining amount to keep the category's totals in sync.
+        // Previously only the balance was updated which caused
+        // remainingAmount to become stale and eventually incorrect
+        // when transactions were added and removed.
         this.balance -= transactionAmount;
+        this.remainingAmount -= transactionAmount;
         this.activity = transactionAmount;
     }
 }


### PR DESCRIPTION
## Summary
- ensure `BudgetCategory.updateBalanceAndActivity` adjusts remaining amount alongside balance
- document reason for fix

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for edu.bhcc:SuperBudget:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.0.6 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 5, column 10)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d0310ba8832ba06076c161520a1c