### PR TITLE
Add BudgetService tests with H2 in-memory database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,17 @@
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/edu/bhcc/SuperBudget/model/BudgetCategory.java
+++ b/src/main/java/edu/bhcc/SuperBudget/model/BudgetCategory.java
@@ -91,6 +91,9 @@ public class BudgetCategory {
         }
 
         this.balance -= transactionAmount;
+        if (this.remainingAmount != null) {
+            this.remainingAmount -= transactionAmount;
+        }
         this.activity = transactionAmount;
     }
 }

--- a/src/test/java/edu/bhcc/SuperBudget/service/BudgetServiceTests.java
+++ b/src/test/java/edu/bhcc/SuperBudget/service/BudgetServiceTests.java
@@ -1,0 +1,57 @@
+package edu.bhcc.SuperBudget.service;
+
+import edu.bhcc.SuperBudget.model.BudgetCategory;
+import edu.bhcc.SuperBudget.model.Transaction;
+import edu.bhcc.SuperBudget.repository.BudgetCategoryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class BudgetServiceTests {
+
+    @Autowired
+    private BudgetService budgetService;
+
+    @Autowired
+    private BudgetCategoryRepository budgetCategoryRepository;
+
+    @Test
+    public void saveTransactionDecreasesBalanceAndRemainingAmount() {
+        BudgetCategory category = new BudgetCategory();
+        category.setName("Food");
+        category.setAllocation(100.0);
+        category.setBalance(100.0);
+        category.setRemainingAmount(100.0);
+        budgetCategoryRepository.save(category);
+
+        Transaction transaction = new Transaction("Groceries", 40.0, category);
+
+        budgetService.saveTransaction(transaction);
+
+        BudgetCategory updated = budgetCategoryRepository.findById(category.getId()).orElseThrow();
+        assertEquals(60.0, updated.getBalance());
+        assertEquals(60.0, updated.getRemainingAmount());
+    }
+
+    @Test
+    public void saveTransactionThrowsWhenInvalid() {
+        BudgetCategory category = new BudgetCategory();
+        category.setName("Utilities");
+        category.setAllocation(50.0);
+        category.setBalance(50.0);
+        category.setRemainingAmount(50.0);
+        budgetCategoryRepository.save(category);
+
+        Transaction tooLarge = new Transaction("Big bill", 60.0, category);
+        assertThrows(IllegalArgumentException.class, () -> budgetService.saveTransaction(tooLarge));
+
+        Transaction noCategory = new Transaction("Uncategorized", 10.0, null);
+        assertThrows(IllegalArgumentException.class, () -> budgetService.saveTransaction(noCategory));
+    }
+}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary
- add tests for BudgetService to cover balance updates and invalid transactions
- configure H2 in-memory database for tests
- ensure BudgetCategory updates remaining amount when saving transactions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d43e3800832ba9969e4536f1f2a2